### PR TITLE
Add safeguard against undefined mimeType in _onBrowsingContextEvent

### DIFF
--- a/src/har-recorder.js
+++ b/src/har-recorder.js
@@ -375,7 +375,7 @@ class HarRecorder {
           this.networkEntries,
           (entry) =>
             entry.contextId === context &&
-            entry.response?.mimeType.startsWith("text/html"),
+            entry.response?.mimeType?.startsWith("text/html"),
         );
       }
 


### PR DESCRIPTION
I've been trying this library for the past week and I noticed some requests come without a `mimeType` (tested on Firefox 115 and 118). 
This leads to the following TypeError (which ultimately cause Selenium tests to fail due to the uncaught error):
```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at /Users/n2o1988/src/test-bidi/node_modules/ff-test-bidi-har-export/src/har-recorder.js:379:37
    at HarRecorder._findLast (/Users/n2o1988/src/test-bidi/node_modules/ff-test-bidi-har-export/src/har-recorder.js:301:11)
    at HarRecorder._onBrowsingContextEvent (/Users/n2o1988/src/test-bidi/node_modules/ff-test-bidi-har-export/src/har-recorder.js:374:29)
    at HarRecorder.recordEvent (/Users/n2o1988/src/test-bidi/node_modules/ff-test-bidi-har-export/src/har-recorder.js:60:14)
    at SeleniumBiDiHarRecorder._onMessage (/Users/n2o1988/src/test-bidi/node_modules/ff-test-bidi-har-export/src/adapters/selenium-bidi-har-recorder.js:130:22)
    at WebSocket.emit (node:events:390:28)
    at WebSocket.emit (node:domain:475:12)
    at Receiver.receiverOnMessage (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/websocket.js:1184:20)
    at Receiver.emit (node:events:390:28)
    at Receiver.emit (node:domain:475:12)
    at Receiver.dataMessage (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/receiver.js:541:14)
    at Receiver.getData (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/receiver.js:459:17)
    at Receiver.startLoop (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/receiver.js:158:22)
    at Receiver._write (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/receiver.js:84:10)
    at writeOrBuffer (node:internal/streams/writable:389:12)
    at _write (node:internal/streams/writable:330:10)
    at Receiver.Writable.write (node:internal/streams/writable:334:10)
    at Socket.socketOnData (/Users/n2o1988/src/test-bidi/node_modules/ws/lib/websocket.js:1278:35)
    at Socket.emit (node:events:390:28)
    at Socket.emit (node:domain:475:12)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:199:23)
```

I saw other parts of the code assuming `mimeType` can falsy, so I thought I'd share this hotfix with the upstream. 
Here's an example of a request that came in with no `mimeType`, causing the above issue:
![Screenshot 2023-10-06 at 23 15 40](https://github.com/firefox-devtools/bidi-har-export/assets/10573340/c3cee8f2-ec28-41db-9b82-bbd95c488969)
