### PR TITLE
Filter out data URLs from HAR generation

### DIFF
--- a/src/har-recorder.js
+++ b/src/har-recorder.js
@@ -310,6 +310,10 @@ class HarRecorder {
     return undefined;
   }
 
+  _isDataURL(url) {
+    return url.startsWith("data:");
+  }
+
   _log(message) {
     if (this._debugLogs) {
       console.log(`[har-recorder] ${message}`);
@@ -319,6 +323,13 @@ class HarRecorder {
   _onBeforeRequestSent(params) {
     const id = params.request.request + "-" + params.redirectCount;
     const url = params.request.url;
+
+    if (this._isDataURL(url)) {
+      // Currently timings for data URLs are completely incorrect and it is not
+      // clear if data URLs are relevant for HAR export.
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1916651
+      return;
+    }
 
     this._log(
       `Event "beforeRequestSent" for url: ${this._shortUrl(url)} (id: ${id})`,
@@ -439,6 +450,14 @@ class HarRecorder {
   _onResponseCompleted(params) {
     const id = params.request.request + "-" + params.redirectCount;
     const url = params.request.url;
+
+    if (this._isDataURL(url)) {
+      // Currently timings for data URLs are completely incorrect and it is not
+      // clear if data URLs are relevant for HAR export.
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1916651
+      return;
+    }
+
     this._log(
       `Event "responseCompleted" for url: ${this._shortUrl(url)} (id: ${id})`,
     );

--- a/test/har-recorder-dataurl.test.js
+++ b/test/har-recorder-dataurl.test.js
@@ -1,0 +1,43 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const { HarRecorder } = require("..");
+const { getMockEvents } = require("./resources/mock-events");
+
+test("HarRecorder generates har export without data URLs", () => {
+  const recorder = new HarRecorder({ browser: "browser", version: "version" });
+
+  recorder.startRecording();
+
+  const requestId = 33;
+  const startTime = Date.now();
+  const {
+    beforeRequestSentEvent,
+    domContentLoadedEvent,
+    loadEvent,
+    responseCompletedEvent,
+  } = getMockEvents(startTime, { requestId });
+
+  // Create 1 additional event for a data url, starting 10 ms before the "main" events.
+  const dataUrlEvents = getMockEvents(startTime - 10);
+  const dataUrl = "data:text/html,foo";
+  dataUrlEvents.beforeRequestSentEvent.params.request.url = dataUrl;
+  dataUrlEvents.responseCompletedEvent.params.request.url = dataUrl;
+
+  recorder.recordEvent(dataUrlEvents.beforeRequestSentEvent);
+  recorder.recordEvent(dataUrlEvents.responseCompletedEvent);
+  recorder.recordEvent(beforeRequestSentEvent);
+  recorder.recordEvent(responseCompletedEvent);
+  recorder.recordEvent(domContentLoadedEvent);
+  recorder.recordEvent(loadEvent);
+
+  const harExport = recorder.stopRecording();
+
+  expect(harExport).toBeDefined();
+  expect(harExport.log).toBeDefined();
+
+  // We should only have one page and one entry, data URL event should be
+  // filtered out.
+  expect(harExport.log.pages.length).toBe(1);
+  expect(harExport.log.entries.length).toBe(1);
+});


### PR DESCRIPTION
Fixes #26

Data URLs are currently created with wrong timings (see https://bugzilla.mozilla.org/show_bug.cgi?id=1916651), and are not necessarily useful in HAR recordings.
Skipping the entries for now and adding a test