### PR TITLE
Support headerValueFormatter function to allow redacting sensitive headers

### DIFF
--- a/src/adapters/events-collection-exporter.js
+++ b/src/adapters/events-collection-exporter.js
@@ -43,15 +43,20 @@ class EventsCollectionExporter {
    *     Should the HarRecorder provide additional logs for debugging.
    * @param {string} options.version
    *     Version of the browser for which we are recording the HAR
+   * @param {Function} [options.headerValueFormatter]
+   *     An optional formatter function to use to format the header value.
+   *     The function should take the header name and value, and return the formatted value.
+   *     If not provided, the original header value will be used.
    */
   constructor(options) {
-    const { browser, debugLogs, events, version } = options;
+    const { browser, debugLogs, events, version, headerValueFormatter } = options;
 
     this._events = events;
     this._recorder = new HarRecorder({
       browser: browser || "firefox",
       debugLogs,
       version: version || "111.0a1",
+      headerValueFormatter,
     });
   }
 

--- a/src/adapters/selenium-bidi-har-recorder.js
+++ b/src/adapters/selenium-bidi-har-recorder.js
@@ -21,13 +21,18 @@ class SeleniumBiDiHarRecorder {
    *     Should the HarRecorder provide additional logs for debugging.
    * @param {object} options.driver
    *     The Selenium driver
+   * @param {Function} [options.headerValueFormatter]
+   *     An optional formatter function to use to format the header value.
+   *     The function should take the header name and value, and return the formatted value.
+   *     If not provided, the original header value will be used.
    */
   constructor(options) {
-    const { browsingContextIds, debugLogs, driver } = options;
+    const { browsingContextIds, debugLogs, driver, headerValueFormatter } = options;
 
     this._browsingContextIds = browsingContextIds;
     this._debugLogs = debugLogs || false;
     this._driver = driver;
+    this._headerValueFormatter = headerValueFormatter;
 
     this._onMessage = this._onMessage.bind(this);
   }
@@ -42,6 +47,7 @@ class SeleniumBiDiHarRecorder {
       browser: capabilities.get("browserName"),
       debugLogs: this._debugLogs,
       version: capabilities.get("browserVersion"),
+      headerValueFormatter: this._headerValueFormatter,
     });
 
     this.bidi = await this._driver.getBidi();

--- a/test/resources/common-resources.js
+++ b/test/resources/common-resources.js
@@ -81,6 +81,13 @@ exports.requestHeaders = [
       value: "?1",
     },
   },
+  {
+    name: "Authorization",
+    value: {
+      type: "string",
+      value: "Bearer 1234"
+    }
+  }
 ];
 
 exports.responseHeaders = [


### PR DESCRIPTION
This PR adds an optional `headerValueFormatter` option to `HarRecorder` (and related adapters), to allow consumers to redact specific headers at runtime. 
The use case is the following: in the network logs we collect there are often sensitive information, such as Authorization headers, Cookie header etc. We'd like to mask these away. We already have extensive logic in our codebase to mask based on the `name` and `value` of the headers, so the most flexible solution for us (and probably for most other consumers) is an optional formatter function. 

Other approaches I've considered:
* passing a list of `headersToMask` strings and masking the `value` based on the presence of the header in such list: this works for simple cases but doesn't work for the `Cookie` header, where in the same cookie we'd have mixed sensitive and non sensitive cookies. 

I've also refactored the test slightly and added a dedicated unit test. 

