### PR TITLE
Fix missing const

### DIFF
--- a/src/task-queue.js
+++ b/src/task-queue.js
@@ -97,7 +97,7 @@ class TaskQueue {
 
       (async () => {
         try {
-          result = await taskWithTimeout;
+          const result = await taskWithTimeout;
           resolve(result);
         } catch (e) {
           reject(e);

--- a/src/task-queue.js
+++ b/src/task-queue.js
@@ -38,7 +38,11 @@ class TaskQueue {
    *     times out or fails.
    */
   queue(taskFn) {
-    const { promise, resolve, reject } = Promise.withResolvers();
+    let resolve, reject;
+    const promise = new Promise((_resolve, _reject) => {
+      reject = _reject;
+      resolve = _resolve;
+    });
 
     this.#queue.push({
       taskFn,
@@ -63,7 +67,10 @@ class TaskQueue {
     }
 
     if (!this.#drainPromise) {
-      const { promise, resolve } = Promise.withResolvers();
+      let resolve;
+      const promise = new Promise((_resolve) => {
+        resolve = _resolve;
+      });
       this.#drainPromise = promise;
       this.#drainResolve = resolve;
     }


### PR DESCRIPTION
Fixes #45 

I introduced a bug during the review cycle, and it wasn't caught by the test, not sure why yet. Maybe slightly different environment which allows properties on globals to be automatically created? 

Also taking the opportunity to remove a `Promise.withResolvers` which could be incompatible with the earliest node versions supported by BrowserTime.

Will add linter and CI in another PR.